### PR TITLE
Add object mode for MiJ writer

### DIFF
--- a/lib/marcjs.js
+++ b/lib/marcjs.js
@@ -229,8 +229,9 @@ TextWriter.format = function(record) {
 // MiJ (MARC-in-JSON) Writer
 //
 
-var MiJWriter = function(stream) {
+var MiJWriter = function(stream, options) {
 
+    this.options = options || { };
     this.count = 0;
 
     this.end = function() {};
@@ -238,12 +239,12 @@ var MiJWriter = function(stream) {
     this.write = function(record) {
         if (this.count) stream.write("\n");
         this.count++;
-        stream.write(MiJWriter.format(record));
+        stream.write(MiJWriter.format(record, options.objectmode));
         stream.write("\n");
     };
 };
 
-MiJWriter.format = function(record) {
+MiJWriter.format = function(record, object) {
     var rec = { leader: record.leader, fields: [ ] };
     record.fields.forEach(function (element) {
         var field = { };
@@ -262,6 +263,7 @@ MiJWriter.format = function(record) {
         }
         rec.fields.push(field);
     });
+    if (object) return rec;
     return JSON.stringify(rec);
 };
 

--- a/lib/marcjs.js
+++ b/lib/marcjs.js
@@ -229,9 +229,8 @@ TextWriter.format = function(record) {
 // MiJ (MARC-in-JSON) Writer
 //
 
-var MiJWriter = function(stream, options) {
+var MiJWriter = function(stream) {
 
-    this.options = options || { };
     this.count = 0;
 
     this.end = function() {};
@@ -239,12 +238,16 @@ var MiJWriter = function(stream, options) {
     this.write = function(record) {
         if (this.count) stream.write("\n");
         this.count++;
-        stream.write(MiJWriter.format(record, options.objectmode));
+        stream.write(MiJWriter.format(record));
         stream.write("\n");
     };
 };
 
-MiJWriter.format = function(record, object) {
+MiJWriter.format = function(record) {
+    return JSON.stringify(MiJWriter.toMiJ(record));
+};
+
+MiJWriter.toMiJ = function (record) {
     var rec = { leader: record.leader, fields: [ ] };
     record.fields.forEach(function (element) {
         var field = { };
@@ -263,8 +266,7 @@ MiJWriter.format = function(record, object) {
         }
         rec.fields.push(field);
     });
-    if (object) return rec;
-    return JSON.stringify(rec);
+    return rec;
 };
 
 


### PR DESCRIPTION
In cases where MiJ records are needed for further processing,
stringifying the results of the formatting merely adds unnecessary
overhead, so this patch adds an object mode to the MiJ writer.