### PR TITLE
Handle Marcxml documents as returned by ZOOM

### DIFF
--- a/lib/marcjs.js
+++ b/lib/marcjs.js
@@ -110,10 +110,13 @@ var MarcxmlReader = function(stream) {
             record = new Record(),
             nr = doc.get('/record'),
             values;
-        record.leader = nr.get('leader').text();
+        nr = nr || doc.root();
         record.fields = [];
         nr.childNodes().forEach(function(element) {
             switch (element.name()) {
+                case 'leader':
+                    record.leader = element.text();
+                    break;
                 case 'controlfield':
                     record.fields.push([
                         element.attr('tag').value(),
@@ -141,7 +144,7 @@ var MarcxmlReader = function(stream) {
     stream.on('data', function(data) {
         buffer += data.toString();
         while (1) {
-            var pos = buffer.indexOf('<record>');
+            var pos = buffer.indexOf('<record');
             if (pos === -1) { return; }
             buffer = buffer.substr(pos);
             pos = buffer.indexOf('</record>');


### PR DESCRIPTION
The ZOOM API returns Marcxml records as documents rather than as
part of a larger document, and explicitly declares the namespace on the
record element. With the changes in this patch, MarcxmlReader can be
hooked straight to the streamed output of a ZOOM query.
