### PR TITLE
Update libxmljs and update iso2709 reader

### DIFF
--- a/lib/marcjs.js
+++ b/lib/marcjs.js
@@ -30,6 +30,7 @@ var Iso2709Reader = function(stream) {
   this.stream = stream;
   this.count = 0;
   this.paused = false;
+  this.data = [];
 
   this.parse = function(data) {
     var record = new Record();
@@ -74,21 +75,23 @@ var Iso2709Reader = function(stream) {
     stream.resume();
   };
 
-  stream.on('readable', function() {
-    var chunk,
-        data,
+  stream.on('data', function(chunk) {
+    self.data.push(chunk);
+  });
+
+  this._read = function() {
+    self.stream.resume();
+  };
+
+  stream.on('end', function(){
+    var data = self.data,
         start = 0,
         pos   = 0,
         len,
         continuePushing = true;
 
-    data = [];
-    while (null !== (chunk = self.stream.read())) {
-      data.push(chunk);
-    }
     data = Buffer.concat(data);
     if (data.length === 0) { return; }
-
     len = data.length;
     while (pos <= len) {
       while ( pos <= len && data[pos] !== 29 ) {
@@ -107,7 +110,7 @@ var Iso2709Reader = function(stream) {
           raw = new Buffer(pos-start +1);
           data.copy(raw, 0, start, pos);
         }
-        self.push(self.parse(raw));
+        self.emit('data', self.parse(raw));
         pos++;
         start = pos;
       }
@@ -118,15 +121,7 @@ var Iso2709Reader = function(stream) {
     } else {
       prevStart = -1; // Marque qu'on n'a rien à garder du précédent buffer
     }
-  });
 
-  this._read = function() {
-    self.stream.resume();
-  };
- 
-
-
-  stream.on('end', function(){
     self.emit('end');
   });
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "async": "~0.2.6",
-    "libxmljs": "^0.14.2",
+    "libxmljs": "^0.15.0",
     "nopt": "~2.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "test": "grunt mochaTest"
   },
   "dependencies": {
-    "libxmljs": "~0.7.1",
-    "nopt": "~2.1.0",
-    "async": "~0.2.6"
+    "async": "~0.2.6",
+    "libxmljs": "^0.14.2",
+    "nopt": "~2.1.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",


### PR DESCRIPTION
This pull request fixes two issues:

- It updates libxmljs to be current. At the moment the old version won't build on OSX, which is problematic.
- It updates the iso2709 reader to match the current streaming spec. This allows it to work with other, modern, JavaScript code.